### PR TITLE
set forwarded-proto header for proxy targets on incoming https requests

### DIFF
--- a/plugin/proxy.go
+++ b/plugin/proxy.go
@@ -90,6 +90,11 @@ func (p *Proxy) Process(echo.HandlerFunc) echo.HandlerFunc {
 		// 	outReq.Header = req.Header
 		// 	p.Logger.Infof("proxy: out request, url=%v", outReq.URL)
 
+		// Tell upstream that the incoming request is https
+		if c.IsTLS() {
+			req.Header.Set(echo.HeaderXForwardedProto, "https")
+		}
+
 		if req.Header.Get(echo.HeaderUpgrade) == "websocket" {
 			p.wsProxy(t).ServeHTTP(res, req)
 		} else {


### PR DESCRIPTION
I run [Drone](https://github.com/drone/drone) behind Armor with AutoTLS enabled.

However, when enabling the Github integration in Drone it generates `http://` URLs for the OAuth2 redirect URL and also for the Github Webhook URLs since it's configured to serve plain HTTP and is unaware of the proxy.

Setting the `X-Forwarded-Proto` header on the request to upstream if the original request was TLS fixes the problem for Drone and probably many others.

I tested the happy paths with Drone but:
* I don't know how it behaves with `Upgrade` requests.
* Also, if the incoming request already includes the header (e.g. from an ELB) it will be overwritten by Armor.
* Furthermore, if the upstream target is https then the header will be set as well although it wouldn't be required.

I don't think any of this leads to problems but I would love your feedback on them.