### PR TITLE
Add "email" parramiter to Armor config

### DIFF
--- a/armor.go
+++ b/armor.go
@@ -30,6 +30,7 @@ type (
 		KeyFile  string `yaml:"key_file"`
 		Auto     bool   `yaml:"auto"`
 		CacheDir string `yaml:"cache_dir"`
+		Email    string `yaml:"email"`
 	}
 
 	Host struct {

--- a/http/http.go
+++ b/http/http.go
@@ -25,6 +25,9 @@ type (
 
 func Init(a *armor.Armor) (h *HTTP) {
 	e := echo.New()
+	// To get some info, when cert expire for example
+	e.AutoTLSManager.Email = a.TLS.Email
+
 	a.Echo = e
 	h = &HTTP{
 		armor:  a,

--- a/website/content/guide/configuration.md
+++ b/website/content/guide/configuration.md
@@ -27,6 +27,7 @@ Name | Type | Description
 `key_file` | string | Key file
 `auto` | bool | Enable automatic certificates from https://letsencrypt.org
 `cache_dir` | string | Cache directory to store certificates from https://letsencrypt.org. Default value `~/.armor/cache`.
+`email` | string | Email optionally specifies a contact email address.
 
 `hosts`
 


### PR DESCRIPTION
This is a good way to advise administrators when the certificates have troubles.

I didn't test it because the `TLS-SNI` challenge is disabled.
But I think this should work.