### PR TITLE
Repair config | directory_url

### DIFF
--- a/armor.go
+++ b/armor.go
@@ -41,7 +41,7 @@ type (
 		Auto         bool   `json:"auto"`
 		CacheDir     string `json:"cache_dir"`
 		Email        string `json:"email"`
-		DirectoryURL string `yaml:"directory_url"`
+		DirectoryURL string `json:"directory_url"`
 	}
 
 	Admin struct {

--- a/cmd/armor/main.go
+++ b/cmd/armor/main.go
@@ -24,7 +24,7 @@ import (
 const (
 	// http://patorjk.com/software/taag/#p=display&f=Small%20Slant&t=Armor
 	banner = `
-   ___                     
+   ___
   / _ | ______ _  ___  ____
  / __ |/ __/  ' \/ _ \/ __/
 /_/ |_/_/ /_/_/_/\___/_/    %s


### PR DESCRIPTION
The configuration structs has been switched to JSON but not all fields has followed.

This repair the config parsing.

By the way this, this is not shown on the [configuration page](https://armor.labstack.com/guide/configuration).
And I can't edit it with the link `Edit this page on GitHub!` which return `error 404`.