### PR TITLE
Add support for TLS client authentication at the host level

### DIFF
--- a/armor.go
+++ b/armor.go
@@ -1,6 +1,7 @@
 package armor
 
 import (
+	"crypto/tls"
 	"sync"
 	"time"
 
@@ -75,6 +76,8 @@ type (
 		Paths       Paths              `json:"paths"`
 		Plugins     []plugin.Plugin    `json:"-"`
 		Echo        *echo.Echo         `json:"-"`
+		ClientCAs   []string           `json:"client_ca_der"`
+		TLSConfig   *tls.Config        `json:"-"`
 	}
 
 	Path struct {

--- a/armor.go
+++ b/armor.go
@@ -76,7 +76,7 @@ type (
 		Paths       Paths              `json:"paths"`
 		Plugins     []plugin.Plugin    `json:"-"`
 		Echo        *echo.Echo         `json:"-"`
-		ClientCAs   []string           `json:"client_ca_der"`
+		ClientCAs   []string           `json:"client_ca"`
 		TLSConfig   *tls.Config        `json:"-"`
 	}
 

--- a/http.go
+++ b/http.go
@@ -49,6 +49,7 @@ func (a *Armor) NewHTTP() (h *HTTP) {
 			ReadTimeout:  a.ReadTimeout * time.Second,
 			WriteTimeout: a.WriteTimeout * time.Second,
 		}
+		e.TLSServer.TLSConfig.GetConfigForClient = a.GetConfigForClient
 		e.AutoTLSManager.Email = a.TLS.Email
 		e.AutoTLSManager.Client = new(acme.Client)
 		if a.TLS.DirectoryURL != "" {

--- a/tls.go
+++ b/tls.go
@@ -1,0 +1,66 @@
+package armor
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+)
+
+// GetConfigForClient implements the 
+func (a *Armor) GetConfigForClient(clientHelloInfo *tls.ClientHelloInfo) (*tls.Config, error) {
+	// Get the host from the hello info
+	host := a.Hosts[clientHelloInfo.ServerName]
+	if len(host.ClientCAs) == 0 {
+		return nil, nil
+	}
+
+	// Use existing host config if exist
+	if host.TLSConfig != nil {
+		return host.TLSConfig, nil
+	}
+
+	// Build and save the host config
+	host.TLSConfig = a.buildTLSConfig(clientHelloInfo, host)
+
+	return host.TLSConfig, nil
+}
+
+func (a *Armor) buildTLSConfig(clientHelloInfo *tls.ClientHelloInfo, host *Host) *tls.Config {
+	// Copy the configurations from the regular server
+	tlsConfig := new(tls.Config)
+	*tlsConfig = *a.Echo.TLSServer.TLSConfig
+
+	// Set the client validation and the certification pool
+	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+	tlsConfig.ClientCAs = a.buildClientCertPool(host)
+
+	return tlsConfig
+}
+
+func (a *Armor) buildClientCertPool(host *Host) (certPool *x509.CertPool) {
+	certPool = x509.NewCertPool()
+
+	// Loop every CA certs given as base64 DER encoding
+	for _, clientCAString := range host.ClientCAs {
+		// Decode base64
+		derBytes, err := base64.StdEncoding.DecodeString(clientCAString)
+		if err != nil {
+			continue
+		}
+		if len(derBytes) == 0 {
+			continue
+		}
+
+		// Parse the DER encoded certificate
+		var caCert *x509.Certificate
+		caCert, err = x509.ParseCertificate(derBytes)
+		if err != nil {
+			continue
+		}
+
+		// Add the certificate to CertPool
+		certPool.AddCert(caCert)
+	}
+
+	return certPool
+}

--- a/website/content/guide/configuration.md
+++ b/website/content/guide/configuration.md
@@ -9,41 +9,42 @@ description = "Armor configuration"
 Armor accepts configuration in YAML format, command-line option `-c` can be used
 to specify a config file, e.g. `armor -c config.yaml`.
 
-Name | Type | Description
-:--- | :--- | :----------
-`address` | string | HTTP listen address e.g. `:8080` listens to all IP address on port 8080
-`read_timeout` | number | Maximum duration in seconds before timing out read of the request
-`write_timeout` | number | Maximum duration before timing out write of the response
-`tls` | object | TLS configuration
-`plugins` | array | Global plugins
-`hosts` | object | Virtual hosts
+| Name            | Type   | Description                                                             |
+| :-------------- | :----- | :---------------------------------------------------------------------- |
+| `address`       | string | HTTP listen address e.g. `:8080` listens to all IP address on port 8080 |
+| `read_timeout`  | number | Maximum duration in seconds before timing out read of the request       |
+| `write_timeout` | number | Maximum duration before timing out write of the response                |
+| `tls`           | object | TLS configuration                                                       |
+| `plugins`       | array  | Global plugins                                                          |
+| `hosts`         | object | Virtual hosts                                                           |
 
 `tls`
 
-Name | Type | Description
-:--- | :--- | :----------
-`address` | string | HTTPS listen address. Default value `:80`
-`cert_file` | string | Certificate file
-`key_file` | string | Key file
-`auto` | bool | Enable automatic certificates from https://letsencrypt.org
-`cache_dir` | string | Cache directory to store certificates from https://letsencrypt.org. Default value `~/.armor/cache`.
-`email` | string | Email optionally specifies a contact email address.
-`directory_url` | string | Defines the ACME CA directory endpoint. If empty, LetsEncryptURL is used (acme.LetsEncryptURL).
+| Name            | Type   | Description                                                                                         |
+| :-------------- | :----- | :-------------------------------------------------------------------------------------------------- |
+| `address`       | string | HTTPS listen address. Default value `:80`                                                           |
+| `cert_file`     | string | Certificate file                                                                                    |
+| `key_file`      | string | Key file                                                                                            |
+| `auto`          | bool   | Enable automatic certificates from https://letsencrypt.org                                          |
+| `cache_dir`     | string | Cache directory to store certificates from https://letsencrypt.org. Default value `~/.armor/cache`. |
+| `email`         | string | Email optionally specifies a contact email address.                                                 |
+| `directory_url` | string | Defines the ACME CA directory endpoint. If empty, LetsEncryptURL is used (acme.LetsEncryptURL).     |
 
 `hosts`
 
-Name | Type | Description
-:--- | :--- | :----------
-`cert_file` | string | Certificate file
-`key_file` | string | Key file
-`plugins` | array | Host plugins
-`paths` | object | Paths
+| Name            | Type   | Description                                                                            |
+| :-------------- | :----- | :------------------------------------------------------------------------------------- |
+| `cert_file`     | string | Certificate file                                                                       |
+| `key_file`      | string | Key file                                                                               |
+| `plugins`       | array  | Host plugins                                                                           |
+| `paths`         | object | Paths                                                                                  |
+| `client_ca_der` | array  | A list of client CA encoded as base64 DER if set client must provide valid certificate |
 
 `paths`
 
-Name | Type | Description
-:--- | :--- | :----------
-`plugins` | array | Path plugins
+| Name      | Type  | Description  |
+| :-------- | :---- | :----------- |
+| `plugins` | array | Path plugins |
 
 ## [Plugins]({{< ref "plugins/redirect.md">}})
 
@@ -92,6 +93,8 @@ hosts:
           targets:
           - url: http://api
   armor.labstack.com:
+    client_ca_der:
+    - "MIIDSzCCAjOgAwI......E/lYx0qGtr0xHQ=="
     paths:
       "/":
         plugins:

--- a/website/content/guide/configuration.md
+++ b/website/content/guide/configuration.md
@@ -32,13 +32,13 @@ to specify a config file, e.g. `armor -c config.yaml`.
 
 `hosts`
 
-| Name            | Type   | Description                                                                            |
-| :-------------- | :----- | :------------------------------------------------------------------------------------- |
-| `cert_file`     | string | Certificate file                                                                       |
-| `key_file`      | string | Key file                                                                               |
-| `plugins`       | array  | Host plugins                                                                           |
-| `paths`         | object | Paths                                                                                  |
-| `client_ca_der` | array  | A list of client CA encoded as base64 DER if set client must provide valid certificate |
+| Name        | Type   | Description                                                                                                                 |
+| :---------- | :----- | :-------------------------------------------------------------------------------------------------------------------------- |
+| `cert_file` | string | Certificate file                                                                                                            |
+| `key_file`  | string | Key file                                                                                                                    |
+| `plugins`   | array  | Host plugins                                                                                                                |
+| `paths`     | object | Paths                                                                                                                       |
+| `client_ca` | array  | A list of client CA (certificate authority) certificate encoded as base64 DER. If set client must provide valid certificate |
 
 `paths`
 


### PR DESCRIPTION
Because I use **Armor** as a _gate way_ for some of my hosts I need to have different **TLS** configuration.

This pull request provides a way to set multiple client **CA** certificates encode into **DER** themselves encoded into **base64** to verify client authentication.

I did not see any test files so I did not made any.

But I updated the documentation accordingly.