### PR TITLE
TLS 1.3 and security feature at the TLS level

### DIFF
--- a/armor.go
+++ b/armor.go
@@ -46,6 +46,7 @@ type (
 		CacheDir     string `json:"cache_dir"`
 		Email        string `json:"email"`
 		DirectoryURL string `json:"directory_url"`
+		Secured      bool `json:"secured"`
 	}
 
 	Admin struct {

--- a/armor.go
+++ b/armor.go
@@ -46,7 +46,7 @@ type (
 		CacheDir     string `json:"cache_dir"`
 		Email        string `json:"email"`
 		DirectoryURL string `json:"directory_url"`
-		Secured      bool `json:"secured"`
+		Secured      bool   `json:"secured"`
 	}
 
 	Admin struct {

--- a/http.go
+++ b/http.go
@@ -45,11 +45,10 @@ func (a *Armor) NewHTTP() (h *HTTP) {
 	if a.TLS != nil {
 		e.TLSServer = &http.Server{
 			Addr:         a.TLS.Address,
-			TLSConfig:    new(tls.Config),
+			TLSConfig:    a.setupTLSConfig(),
 			ReadTimeout:  a.ReadTimeout * time.Second,
 			WriteTimeout: a.WriteTimeout * time.Second,
 		}
-		e.TLSServer.TLSConfig.GetConfigForClient = a.GetConfigForClient
 		e.AutoTLSManager.Email = a.TLS.Email
 		e.AutoTLSManager.Client = new(acme.Client)
 		if a.TLS.DirectoryURL != "" {

--- a/tls.go
+++ b/tls.go
@@ -4,7 +4,12 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"os"
 )
+
+func init() {
+	os.Setenv("GODEBUG", os.Getenv("GODEBUG")+",tls13=1")
+}
 
 // GetConfigForClient implements the Config.GetClientCertificate callback
 func (a *Armor) GetConfigForClient(clientHelloInfo *tls.ClientHelloInfo) (*tls.Config, error) {

--- a/tls.go
+++ b/tls.go
@@ -11,6 +11,27 @@ func init() {
 	os.Setenv("GODEBUG", os.Getenv("GODEBUG")+",tls13=1")
 }
 
+// setupTLSConfig builds the TLS configuration
+func (a *Armor) setupTLSConfig() *tls.Config {
+	ret := new(tls.Config)
+	ret.GetConfigForClient = a.GetConfigForClient
+
+	if a.TLS.Secured {
+		ret.MinVersion = tls.VersionTLS12
+		ret.CipherSuites = []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		}
+	}
+
+	return ret
+}
+
 // GetConfigForClient implements the Config.GetClientCertificate callback
 func (a *Armor) GetConfigForClient(clientHelloInfo *tls.ClientHelloInfo) (*tls.Config, error) {
 	// Get the host from the hello info

--- a/tls.go
+++ b/tls.go
@@ -13,12 +13,12 @@ func init() {
 
 // setupTLSConfig builds the TLS configuration
 func (a *Armor) setupTLSConfig() *tls.Config {
-	ret := new(tls.Config)
-	ret.GetConfigForClient = a.GetConfigForClient
+	cfg := new(tls.Config)
+	cfg.GetConfigForClient = a.GetConfigForClient
 
 	if a.TLS.Secured {
-		ret.MinVersion = tls.VersionTLS12
-		ret.CipherSuites = []uint16{
+		cfg.MinVersion = tls.VersionTLS12
+		cfg.CipherSuites = []uint16{
 			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
@@ -29,7 +29,7 @@ func (a *Armor) setupTLSConfig() *tls.Config {
 		}
 	}
 
-	return ret
+	return cfg
 }
 
 // GetConfigForClient implements the Config.GetClientCertificate callback

--- a/tls.go
+++ b/tls.go
@@ -39,7 +39,7 @@ func (a *Armor) GetConfigForClient(clientHelloInfo *tls.ClientHelloInfo) (*tls.C
 	// If the host or the clientCAs are not configured the function
 	// returns the default TLS configuration
 	if host == nil || len(host.ClientCAs) == 0 {
-		return a.setupTLSConfig(), nil
+		return nil, nil
 	}
 
 	// Use existing host config if exist

--- a/website/content/guide/configuration.md
+++ b/website/content/guide/configuration.md
@@ -20,15 +20,16 @@ to specify a config file, e.g. `armor -c config.yaml`.
 
 `tls`
 
-| Name            | Type   | Description                                                                                         |
-| :-------------- | :----- | :-------------------------------------------------------------------------------------------------- |
-| `address`       | string | HTTPS listen address. Default value `:80`                                                           |
-| `cert_file`     | string | Certificate file                                                                                    |
-| `key_file`      | string | Key file                                                                                            |
-| `auto`          | bool   | Enable automatic certificates from https://letsencrypt.org                                          |
-| `cache_dir`     | string | Cache directory to store certificates from https://letsencrypt.org. Default value `~/.armor/cache`. |
-| `email`         | string | Email optionally specifies a contact email address.                                                 |
-| `directory_url` | string | Defines the ACME CA directory endpoint. If empty, LetsEncryptURL is used (acme.LetsEncryptURL).     |
+| Name            | Type   | Description                                                                                                 |
+| :-------------- | :----- | :---------------------------------------------------------------------------------------------------------- |
+| `address`       | string | HTTPS listen address. Default value `:80`                                                                   |
+| `cert_file`     | string | Certificate file                                                                                            |
+| `key_file`      | string | Key file                                                                                                    |
+| `auto`          | bool   | Enable automatic certificates from https://letsencrypt.org                                                  |
+| `cache_dir`     | string | Cache directory to store certificates from https://letsencrypt.org. Default value `~/.armor/cache`.         |
+| `email`         | string | Email optionally specifies a contact email address.                                                         |
+| `directory_url` | string | Defines the ACME CA directory endpoint. If empty, LetsEncryptURL is used (acme.LetsEncryptURL).             |
+| `secured`       | bool   | If enable, the minimum TLS version is set to 1.2, the ciphers are AEAD and forward secrecy algorithms only. |
 
 `hosts`
 


### PR DESCRIPTION
The changes add: 

- support for TLS 1.3 with the DEBUG flag: `tls13=1` as explained in the [documentation](https://golang.org/pkg/crypto/tls/#pkg-overview).
- strict TLS configuration with TLS 1.2 minimum version, AEAD and forward secrecy ciphers only.
- documentation updated accordingly.